### PR TITLE
Show render button when video missing in gallery

### DIFF
--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -56,7 +56,7 @@
         <summary>
             <h2>Walk {{ walk[0] }}: {{ walk[1] }} ({{ walk[2] }}, step rate {{ walk[4] }})
                 <button class="delete-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Delete</button>
-                {% if images|length < walk[3] %}
+                {% if images|length < walk[3] or not videos_by_walk.get(walk[0]) %}
                 <button class="enqueue-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Render</button>
                 {% endif %}
                 {% if videos_by_walk.get(walk[0]) %}


### PR DESCRIPTION
## Summary
- Display the Render button for walks without an existing video to allow queueing rendering

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b9f390184c83258dc94709f2e69bfe