### PR TITLE
Hide thumbnails when walk expanded

### DIFF
--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -34,6 +34,7 @@
         summary { cursor: pointer; list-style: none; }
         summary::-webkit-details-marker { display: none; }
         .thumbs { display: flex; gap: 10px; justify-content: center; margin-top: 10px; }
+        .walk[open] .thumbs { display: none; }
         .thumbs img { width: 150px; height: auto; border-radius: 8px; }
         #videoOverlay { position: fixed; top:0; left:0; width:100%; height:100%; background: rgba(0,0,0,0.8); display:none; align-items:center; justify-content:center; }
         #videoOverlay video { max-width:90%; max-height:90%; }


### PR DESCRIPTION
## Summary
- hide start and end thumbnails when a walk's detail view is opened so only image gallery is visible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9f65205308325ae256df8cbb78f8f