### PR TITLE
Fix render queue updates in gallery

### DIFF
--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -61,12 +61,12 @@
     <details class="walk">
         <summary>
             <h2>Walk {{ walk[0] }}: {{ walk[1] }} ({{ walk[2] }}, step rate {{ walk[4] }})
-                <button class="delete-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Delete</button>
+                <button type="button" class="delete-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Delete</button>
                 {% if images|length < walk[3] or not videos_by_walk.get(walk[0]) %}
-                <button class="enqueue-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Render</button>
+                <button type="button" class="enqueue-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Render</button>
                 {% endif %}
                 {% if videos_by_walk.get(walk[0]) %}
-                <button class="play-video" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Play Video</button>
+                <button type="button" class="play-video" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Play Video</button>
                 {% endif %}
             </h2>
             <div class="thumbs">
@@ -221,9 +221,20 @@
                 btn.addEventListener('click', () => {
                     const walkId = btn.getAttribute('data-walk-id');
                     fetch(`/enqueue_walk/${walkId}`, { method: 'POST' })
-                    .then(response => response.json())
-                    .then(() => alert(`Walk ${walkId} queued for rendering.`))
-                    .catch(err => console.error('Error:', err));
+                    .then(response => {
+                        if (!response.ok) {
+                            throw new Error(`Server responded with ${response.status}`);
+                        }
+                        return response.json();
+                    })
+                    .then(() => {
+                        alert(`Walk ${walkId} queued for rendering.`);
+                        fetchQueueStatus();
+                    })
+                    .catch(err => {
+                        console.error('Error:', err);
+                        alert(`Failed to queue walk ${walkId}.`);
+                    });
                 });
             });
 


### PR DESCRIPTION
## Summary
- prevent gallery buttons from submitting forms by declaring `type="button"`
- refresh the render queue list and handle errors after enqueuing a walk

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9f7f0b6388325b8161a9ef181e2e0