### PR TITLE
Refresh gallery when render completes and add download button

### DIFF
--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -31,6 +31,8 @@
         #createWalkBtn:hover { background-color: #218838; }
         .delete-walk { padding: 5px 10px; margin-left: 10px; font-size: 14px; cursor: pointer; border-radius: 4px; border: none; background-color: #dc3545; color: white; }
         .delete-walk:hover { background-color: #c82333; }
+        .play-video, .download-video { padding: 5px 10px; margin-left: 10px; font-size: 14px; cursor: pointer; border-radius: 4px; border: none; background-color: #28a745; color: white; }
+        .play-video:hover, .download-video:hover { background-color: #218838; }
         summary { cursor: pointer; list-style: none; }
         summary::-webkit-details-marker { display: none; }
         .thumbs { display: flex; gap: 10px; justify-content: center; margin-top: 10px; }
@@ -69,6 +71,7 @@
                 {% endif %}
                 {% if videos_by_walk.get(walk[0]) %}
                 <button type="button" class="play-video" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Play Video</button>
+                <button type="button" class="download-video" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Download Video</button>
                 {% endif %}
             </h2>
             <div class="thumbs">
@@ -105,11 +108,17 @@
             const queueInput = document.getElementById('queueInput');
             const queueList = document.getElementById('queueList');
             let selectedIds = [];
+            let lastRendering = null;
 
             function fetchQueueStatus() {
                 fetch('/queue_status')
                 .then(res => res.json())
                 .then(data => {
+                    if (lastRendering && data.rendering !== lastRendering) {
+                        window.location.reload();
+                        return;
+                    }
+                    lastRendering = data.rendering;
                     queueList.innerHTML = '';
                     if (data.rendering) {
                         const li = document.createElement('li');
@@ -255,6 +264,18 @@
                     video.src = `/generated_videos/${walkId}/walk.mp4`;
                     overlay.style.display = 'flex';
                     video.play();
+                });
+            });
+
+            document.querySelectorAll('.download-video').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const walkId = btn.getAttribute('data-walk-id');
+                    const link = document.createElement('a');
+                    link.href = `/generated_videos/${walkId}/walk.mp4`;
+                    link.download = `walk_${walkId}.mp4`;
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
                 });
             });
 


### PR DESCRIPTION
## Summary
- Refresh gallery page when rendering finishes so new videos appear automatically
- Add green play and download buttons and enable video downloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ba405f155083259cdd221ef2011ac5