### PR TITLE
Enable step selection and add pre-render option

### DIFF
--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -27,12 +27,12 @@
         .img-container input:checked ~ .selection-order {
             display: flex;
         }
-        #createWalkBtn { padding: 10px 20px; font-size: 16px; cursor: pointer; border-radius: 5px; border: none; background-color: #28a745; color: white; }
-        #createWalkBtn:hover { background-color: #218838; }
+        #createWalkBtn, #preRenderBtn { padding: 10px 20px; font-size: 16px; cursor: pointer; border-radius: 5px; border: none; background-color: #28a745; color: white; }
+        #createWalkBtn:hover, #preRenderBtn:hover { background-color: #218838; }
         .delete-walk { padding: 5px 10px; margin-left: 10px; font-size: 14px; cursor: pointer; border-radius: 4px; border: none; background-color: #dc3545; color: white; }
         .delete-walk:hover { background-color: #c82333; }
-        .play-video, .download-video { padding: 5px 10px; margin-left: 10px; font-size: 14px; cursor: pointer; border-radius: 4px; border: none; background-color: #28a745; color: white; }
-        .play-video:hover, .download-video:hover { background-color: #218838; }
+        .play-video, .download-video, .enqueue-walk { padding: 5px 10px; margin-left: 10px; font-size: 14px; cursor: pointer; border-radius: 4px; border: none; background-color: #28a745; color: white; }
+        .play-video:hover, .download-video:hover, .enqueue-walk:hover { background-color: #218838; }
         summary { cursor: pointer; list-style: none; }
         summary::-webkit-details-marker { display: none; }
         .thumbs { display: flex; gap: 10px; justify-content: center; margin-top: 10px; }
@@ -52,6 +52,7 @@
         <label><input type="checkbox" id="loopInput"> Loop walk</label>
         <label><input type="checkbox" id="queueInput" checked> Queue</label>
         <button id="createWalkBtn">Create Custom Walk From Selection</button>
+        <button id="preRenderBtn">Pre-render Selection</button>
         <p id="status"></p>
     </div>
 
@@ -102,6 +103,7 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const createWalkBtn = document.getElementById('createWalkBtn');
+            const preRenderBtn = document.getElementById('preRenderBtn');
             const statusEl = document.getElementById('status');
             const stepsInput = document.getElementById('stepsInput');
             const loopInput = document.getElementById('loopInput');
@@ -202,6 +204,36 @@
                             alert('Custom walk created! You will now be redirected to the main page.');
                             window.location.href = '/index?autoplay=true';
                         }
+                    } else {
+                        throw new Error(data.message);
+                    }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    statusEl.textContent = `Error: ${error.message}`;
+                    alert(`Error: ${error.message}`);
+                });
+            });
+
+            preRenderBtn.addEventListener('click', () => {
+                if (selectedIds.length < 2) {
+                    alert('Please select at least two images to create a walk.');
+                    return;
+                }
+
+                statusEl.textContent = 'Queuing walk for rendering...';
+
+                const steps = parseInt(stepsInput.value, 10) || 60;
+                fetch('/create_custom_walk', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ids: selectedIds, steps: steps, loop: loopInput.checked, queue: true })
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.status === 'queued' || data.status === 'success') {
+                        statusEl.textContent = `Walk ${data.walk_id} queued for rendering.`;
+                        fetchQueueStatus();
                     } else {
                         throw new Error(data.message);
                     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,8 @@
     <h1>StyleGAN Walk</h1>
     <div>
         <button id="play">Play</button>
+        <label for="randSteps">Steps:</label>
+        <input type="number" id="randSteps" value="120" min="2" style="width: 80px;" />
         <button id="startRandom">Start Random Walk</button>
         <button id="stop">Stop</button>
         <a href="/gallery">Gallery</a>
@@ -49,7 +51,12 @@
         });
 
         document.getElementById('startRandom').addEventListener('click', async () => {
-            await fetch('/start_random_walk', { method: 'POST' });
+            const steps = parseInt(document.getElementById('randSteps').value, 10) || 120;
+            await fetch('/start_random_walk', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ steps })
+            });
             running = true;
             fetchLoop();
         });


### PR DESCRIPTION
## Summary
- Allow step selection for random walks on the home page
- Add a pre-render button in the gallery that queues selected images using the current settings
- Style render buttons in the gallery with a consistent green theme

## Testing
- `python -m py_compile stylegan_server.py && echo py_compile_success`


------
https://chatgpt.com/codex/tasks/task_b_68ba45b6adc883259b31aeadedf82799