### PR TITLE
Expose rerendering controls in gallery

### DIFF
--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -27,8 +27,8 @@
         .img-container input:checked ~ .selection-order {
             display: flex;
         }
-        #createWalkBtn, #preRenderBtn { padding: 10px 20px; font-size: 16px; cursor: pointer; border-radius: 5px; border: none; background-color: #28a745; color: white; }
-        #createWalkBtn:hover, #preRenderBtn:hover { background-color: #218838; }
+        #createWalkBtn { padding: 10px 20px; font-size: 16px; cursor: pointer; border-radius: 5px; border: none; background-color: #28a745; color: white; }
+        #createWalkBtn:hover { background-color: #218838; }
         .delete-walk { padding: 5px 10px; margin-left: 10px; font-size: 14px; cursor: pointer; border-radius: 4px; border: none; background-color: #dc3545; color: white; }
         .delete-walk:hover { background-color: #c82333; }
         .play-video, .download-video, .enqueue-walk { padding: 5px 10px; margin-left: 10px; font-size: 14px; cursor: pointer; border-radius: 4px; border: none; background-color: #28a745; color: white; }
@@ -52,7 +52,6 @@
         <label><input type="checkbox" id="loopInput"> Loop walk</label>
         <label><input type="checkbox" id="queueInput" checked> Queue</label>
         <button id="createWalkBtn">Create Custom Walk From Selection</button>
-        <button id="preRenderBtn">Pre-render Selection</button>
         <p id="status"></p>
     </div>
 
@@ -67,9 +66,7 @@
         <summary>
             <h2>Walk {{ walk[0] }}: {{ walk[1] }} ({{ walk[2] }}, step rate {{ walk[4] }})
                 <button type="button" class="delete-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Delete</button>
-                {% if images|length < walk[3] or not videos_by_walk.get(walk[0]) %}
                 <button type="button" class="enqueue-walk" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Render</button>
-                {% endif %}
                 {% if videos_by_walk.get(walk[0]) %}
                 <button type="button" class="play-video" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Play Video</button>
                 <button type="button" class="download-video" data-walk-id="{{ walk[0] }}" onclick="event.stopPropagation();">Download Video</button>
@@ -103,7 +100,6 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const createWalkBtn = document.getElementById('createWalkBtn');
-            const preRenderBtn = document.getElementById('preRenderBtn');
             const statusEl = document.getElementById('status');
             const stepsInput = document.getElementById('stepsInput');
             const loopInput = document.getElementById('loopInput');
@@ -204,36 +200,6 @@
                             alert('Custom walk created! You will now be redirected to the main page.');
                             window.location.href = '/index?autoplay=true';
                         }
-                    } else {
-                        throw new Error(data.message);
-                    }
-                })
-                .catch(error => {
-                    console.error('Error:', error);
-                    statusEl.textContent = `Error: ${error.message}`;
-                    alert(`Error: ${error.message}`);
-                });
-            });
-
-            preRenderBtn.addEventListener('click', () => {
-                if (selectedIds.length < 2) {
-                    alert('Please select at least two images to create a walk.');
-                    return;
-                }
-
-                statusEl.textContent = 'Queuing walk for rendering...';
-
-                const steps = parseInt(stepsInput.value, 10) || 60;
-                fetch('/create_custom_walk', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ ids: selectedIds, steps: steps, loop: loopInput.checked, queue: true })
-                })
-                .then(response => response.json())
-                .then(data => {
-                    if (data.status === 'queued' || data.status === 'success') {
-                        statusEl.textContent = `Walk ${data.walk_id} queued for rendering.`;
-                        fetchQueueStatus();
                     } else {
                         throw new Error(data.message);
                     }


### PR DESCRIPTION
## Summary
- Remove unused "Pre-render Selection" option from gallery controls
- Allow the "Render" button to queue already-rendered walks again

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba8c60dfd08325b31e8a1816f9c8b2