### PR TITLE
Add keyframes option to random walk

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ python stylegan_server.py
 Generate images by performing a latent walk:
 
 ```bash
-# define a random walk and load it
-curl -X POST http://localhost:5000/start_random_walk
+# define a random walk with 120 steps and 4 keyframes and load it
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"steps":120,"keyframes":4}' \
+     http://localhost:5000/start_random_walk
 
 # fetch the next image in the walk (PNG binary response)
 curl -o frame.png http://localhost:5000/next_image

--- a/stylegan_server.py
+++ b/stylegan_server.py
@@ -290,10 +290,17 @@ def index_page():
 def start_random_walk():
     """Defines a new random walk, saves it, and loads it for rendering."""
     segments = 1
-    if request.is_json and "segments" in request.json:
-        segments = int(request.json["segments"])
+    if request.is_json:
+        if "keyframes" in request.json:
+            segments = max(int(request.json["keyframes"]) - 1, 1)
+        elif "segments" in request.json:
+            segments = int(request.json["segments"])
     else:
-        segments = int(request.args.get("segments", 1))
+        keyframes_arg = request.args.get("keyframes")
+        if keyframes_arg is not None:
+            segments = max(int(keyframes_arg) - 1, 1)
+        else:
+            segments = int(request.args.get("segments", 1))
 
     step_rate = num_steps
     if request.is_json and "steps" in request.json:

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,8 @@
         <button id="play">Play</button>
         <label for="randSteps">Steps:</label>
         <input type="number" id="randSteps" value="120" min="2" style="width: 80px;" />
+        <label for="randKeyframes">Keyframes:</label>
+        <input type="number" id="randKeyframes" value="2" min="2" style="width: 80px;" />
         <button id="startRandom">Start Random Walk</button>
         <button id="stop">Stop</button>
         <a href="/gallery">Gallery</a>
@@ -52,10 +54,11 @@
 
         document.getElementById('startRandom').addEventListener('click', async () => {
             const steps = parseInt(document.getElementById('randSteps').value, 10) || 120;
+            const keyframes = parseInt(document.getElementById('randKeyframes').value, 10) || 2;
             await fetch('/start_random_walk', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ steps })
+                body: JSON.stringify({ steps, keyframes })
             });
             running = true;
             fetchLoop();


### PR DESCRIPTION
## Summary
- Allow specifying keyframe count when starting random walks
- Support new keyframe parameter in `/start_random_walk`
- Document keyframe usage in README

## Testing
- `python -m py_compile stylegan_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68ba90bf651c8325af3afd97697636e6