### PR TITLE
Allow re-rendered walks to override step rate

### DIFF
--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -266,7 +266,12 @@
             document.querySelectorAll('.enqueue-walk').forEach(btn => {
                 btn.addEventListener('click', () => {
                     const walkId = btn.getAttribute('data-walk-id');
-                    fetch(`/enqueue_walk/${walkId}`, { method: 'POST' })
+                    const steps = parseInt(stepsInput.value, 10) || 60;
+                    fetch(`/enqueue_walk/${walkId}`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ steps })
+                    })
                     .then(response => {
                         if (!response.ok) {
                             throw new Error(`Server responded with ${response.status}`);


### PR DESCRIPTION
## Summary
- allow gallery renders to specify a new step rate
- re-interpolate curated walks in `/enqueue_walk` using the supplied rate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68baa395cc988325b73baa84dba36b01