### PR TITLE
Keep restored walks in archive

### DIFF
--- a/stylegan_server.py
+++ b/stylegan_server.py
@@ -427,7 +427,7 @@ def delete_archived_walk(walk_id):
 
 @app.route('/restore_walk/<int:archived_id>', methods=['POST'])
 def restore_walk(archived_id):
-    """Restores a walk from the archive to the main database."""
+    """Restore a walk to the main database without removing it from the archive."""
     queue_flag = request.args.get('queue') in ('1', 'true', 'yes')
 
     restored_id = db_restore_walk(ARCHIVE_DB_FILE, DB_FILE, archived_id)


### PR DESCRIPTION
## Summary
- prevent archive entries from being deleted when restoring walks
- document new behavior in restore endpoint

## Testing
- `python -m py_compile stylegan_manager/db.py stylegan_server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68baba1bbe28832584adf6f5f5ae39b1