### PR TITLE
Add latent sampler and expose random walk parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,20 @@ python stylegan_server.py
 Generate images by performing a latent walk:
 
 ```bash
-# define a random walk with 120 steps and 4 keyframes and load it
+# define a random walk with 120 steps in range [-1.5, 1.5] and load it
 curl -X POST -H "Content-Type: application/json" \
-     -d '{"steps":120,"keyframes":4}' \
+     -d '{"steps":120,"keyframes":4,"extent":1.5}' \
      http://localhost:5000/start_random_walk
 
 # fetch the next image in the walk (PNG binary response)
 curl -o frame.png http://localhost:5000/next_image
 ```
+
+Latent vectors are generated via the ``sample_latents`` utility, which draws
+bounded samples from a standard normal distribution and optionally mixes in a
+Sobol low-discrepancy sequence.  The ``/start_random_walk`` endpoint accepts
+``steps`` (or ``n_vectors``) to control how many vectors are generated and an
+``extent`` value that limits sampling to ``[-extent, extent]``.
 
 Visit `http://localhost:5000/gallery` to browse saved walks and images. The
 gallery interface also allows creating curated walks by interpolating between

--- a/stylegan_manager/utils/__init__.py
+++ b/stylegan_manager/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers for StyleGAN server."""
 
 from .interpolation import LatentInterpolator
+from .sampler import sample_latents
 
-__all__ = ["LatentInterpolator"]
+__all__ = ["LatentInterpolator", "sample_latents"]

--- a/stylegan_manager/utils/sampler.py
+++ b/stylegan_manager/utils/sampler.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Optional
+import numpy as np
+
+
+def sample_latents(
+    z_dim: int,
+    n_vectors: int,
+    extent: float = 2.0,
+    seed: Optional[int] = None,
+) -> np.ndarray:
+    """Generate latent vectors bounded by ``[-extent, extent]``.
+
+    Vectors are drawn from a standard normal distribution using
+    :func:`numpy.random.default_rng`.  If SciPy's quasi-Monte Carlo tools are
+    available, a Sobol sequence is mixed in to provide better coverage of the
+    latent space.
+    """
+    rng = np.random.default_rng(seed)
+    latents = rng.standard_normal((n_vectors, z_dim))
+    latents = np.clip(latents, -extent, extent)
+
+    # Optionally blend with a Sobol low-discrepancy sequence for coverage.
+    try:  # pragma: no cover - SciPy may not be installed
+        from scipy.stats import qmc
+
+        sobol = qmc.Sobol(d=z_dim, scramble=True, seed=seed)
+        quasi = sobol.random(n_vectors)
+        quasi = qmc.scale(quasi, l_bounds=-extent, u_bounds=extent)
+        latents = (latents + quasi) / 2.0
+    except Exception:
+        pass
+
+    return latents.astype(np.float32)

--- a/stylegan_manager/walks/random_walk.py
+++ b/stylegan_manager/walks/random_walk.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import numpy as np
 from PIL import Image
 
 from .base import Walk
+from ..utils import sample_latents
 
 
 class RandomWalk(Walk):
@@ -13,11 +16,18 @@ class RandomWalk(Walk):
         super().__init__(model, **kwargs)
         self.steps = steps
 
-    def generate(self) -> None:
+    def generate(
+        self,
+        n_vectors: Optional[int] = None,
+        extent: float = 2.0,
+        seed: Optional[int] = None,
+    ) -> None:
         self.frames = []
         latent_dim = getattr(self.model, "latent_dim", 512)
-        for _ in range(self.steps):
-            z = np.random.randn(1, latent_dim)
+        count = n_vectors if n_vectors is not None else self.steps
+        latents = sample_latents(latent_dim, count, extent=extent, seed=seed)
+        for z in latents:
+            z = z[np.newaxis, :]
             if hasattr(self.model, "generate_image"):
                 img = self.model.generate_image(z)
             else:


### PR DESCRIPTION
## Summary
- add `sample_latents` utility with optional Sobol-based coverage
- use sampler in `RandomWalk` and expose `n_vectors`/`extent`
- update random walk API and README documentation

## Testing
- `python -m pytest`
- `python -m py_compile stylegan_manager/utils/sampler.py stylegan_manager/walks/random_walk.py stylegan_manager/utils/__init__.py stylegan_server.py`

------
https://chatgpt.com/codex/tasks/task_b_68bac0fdb56083258b1640f03a800b8e