### PR TITLE
feat: expose extent parameter in random walk UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,8 @@
         <input type="number" id="randSteps" value="120" min="2" style="width: 80px;" />
         <label for="randKeyframes">Keyframes:</label>
         <input type="number" id="randKeyframes" value="2" min="2" style="width: 80px;" />
+        <label for="randExtent">Extent:</label>
+        <input type="number" id="randExtent" value="2.0" step="0.1" style="width: 80px;" />
         <button id="startRandom">Start Random Walk</button>
         <button id="stop">Stop</button>
         <a href="/gallery">Gallery</a>
@@ -55,10 +57,11 @@
         document.getElementById('startRandom').addEventListener('click', async () => {
             const steps = parseInt(document.getElementById('randSteps').value, 10) || 120;
             const keyframes = parseInt(document.getElementById('randKeyframes').value, 10) || 2;
+            const extent = parseFloat(document.getElementById('randExtent').value) || 2.0;
             await fetch('/start_random_walk', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ steps, keyframes })
+                body: JSON.stringify({ steps, keyframes, extent })
             });
             running = true;
             fetchLoop();


### PR DESCRIPTION
## Summary
- allow configuring sampling extent in the random walk UI
- send extent value with `/start_random_walk` request

## Testing
- `python -m py_compile stylegan_server.py`
- `for f in $(git ls-files '*.py'); do python -m py_compile "$f" || echo "Failed: $f"; done` *(fails: source code string cannot contain null bytes in training/.___init__.py, training/._training_loop.py, training/._training_loop2.py, training/._training_loop3.py)*

------
https://chatgpt.com/codex/tasks/task_b_68bac8f915c083259368e3d186de6412