### PR TITLE
Add liked flag and utilities for generated images

### DIFF
--- a/stylegan_server.py
+++ b/stylegan_server.py
@@ -391,13 +391,14 @@ def gallery_page():
     all_walks = fetch_all_walks(DB_FILE)
 
     images_by_walk = {}
-    for img_id, walk_id, relpath in fetch_all_images(DB_FILE):
+    for img_id, walk_id, relpath, liked in fetch_all_images(DB_FILE):
         if walk_id not in images_by_walk:
             images_by_walk[walk_id] = []
         fname = relpath.split('/', 1)[1] if '/' in relpath else relpath
         images_by_walk[walk_id].append({
             'id': img_id,
             'filename': fname,
+            'liked': bool(liked),
         })
 
     videos_by_walk = {}


### PR DESCRIPTION
## Summary
- track a `liked` state for generated images and index it for quick queries
- expose helpers to toggle liked images and retrieve them with optional filtering
- adjust gallery generation to surface liked status

## Testing
- `python -m py_compile stylegan_manager/db.py stylegan_server.py`
- `pytest`
- `pip install numpy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68baca84b15c832593324c0a30a953ff