### PR TITLE
Refactor gallery filter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Visit `http://localhost:5000/gallery` to browse saved walks and images. The
 gallery interface also allows creating curated walks by interpolating between
 selected keyframes.
 
+### Gallery Filters
+
+The gallery view supports optional query parameters to control which images are
+shown. Filters are parsed by the server and mirrored on the client so that
+additional types can be added with minimal changes. Currently the following
+filter is available:
+
+* `liked=1` – only display images that have been marked as liked.
+
+Future filters can be introduced by extending the server's filter parser and
+adding corresponding UI elements in the gallery template.
+
 ## Library usage
 
 The project now exposes a lightweight Python package, ``stylegan_manager``,

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -63,7 +63,7 @@
     <p>Select images in the order you want to create a new walk. <a href="/">Back to Generator</a> | <a href="/archive">Archived Walks</a></p>
 
     <div class="controls">
-        <label><input type="checkbox" id="likedOnlyToggle" {% if liked_only %}checked{% endif %}> Show liked only</label>
+        <label><input type="checkbox" id="likedOnlyToggle" {% if filters.liked %}checked{% endif %}> Show liked only</label>
     </div>
 
     <div class="controls">
@@ -202,15 +202,21 @@
             fetchQueueStatus();
             setInterval(fetchQueueStatus, 5000);
 
+            function updateFilters(newFilters) {
+                const params = new URLSearchParams(window.location.search);
+                Object.entries(newFilters).forEach(([key, value]) => {
+                    if (value === null || value === undefined || value === false) {
+                        params.delete(key);
+                    } else {
+                        params.set(key, value);
+                    }
+                });
+                window.location.search = params.toString();
+            }
+
             if (likedOnlyToggle) {
                 likedOnlyToggle.addEventListener('change', () => {
-                    const params = new URLSearchParams(window.location.search);
-                    if (likedOnlyToggle.checked) {
-                        params.set('liked', '1');
-                    } else {
-                        params.delete('liked');
-                    }
-                    window.location.search = params.toString();
+                    updateFilters({ liked: likedOnlyToggle.checked ? '1' : null });
                 });
             }
 


### PR DESCRIPTION
## Summary
- factor out gallery filter parsing into a helper for reuse
- update gallery template JavaScript to build URLs from a filter map
- document gallery filters in the README

## Testing
- `python -m py_compile stylegan_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68bad1ac5d908325a3ff1be540e797c4