### PR TITLE
Add noise scoring and gallery ordering

### DIFF
--- a/stylegan_manager/utils/__init__.py
+++ b/stylegan_manager/utils/__init__.py
@@ -2,5 +2,6 @@
 
 from .interpolation import LatentInterpolator
 from .sampler import sample_latents
+from .noise import compute_noise_score
 
-__all__ = ["LatentInterpolator", "sample_latents"]
+__all__ = ["LatentInterpolator", "sample_latents", "compute_noise_score"]

--- a/stylegan_manager/utils/noise.py
+++ b/stylegan_manager/utils/noise.py
@@ -1,0 +1,14 @@
+import numpy as np
+from PIL import Image, ImageFilter
+
+
+def compute_noise_score(img: Image.Image) -> float:
+    """Compute a simple noise metric for an image.
+
+    The metric is the variance of a high-pass filtered version of the image.
+    A higher value indicates more high-frequency content (noise).
+    """
+    gray = img.convert("L")
+    blurred = gray.filter(ImageFilter.GaussianBlur(radius=1))
+    high_pass = np.asarray(gray, dtype=np.float32) - np.asarray(blurred, dtype=np.float32)
+    return float(np.var(high_pass))

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -64,6 +64,11 @@
 
     <div class="controls">
         <label><input type="checkbox" id="likedOnlyToggle" {% if filters.liked %}checked{% endif %}> Show liked only</label>
+        <label for="orderSelect">Order:</label>
+        <select id="orderSelect">
+            <option value="" {% if not filters.order %}selected{% endif %}>Default</option>
+            <option value="noise" {% if filters.order == 'noise' %}selected{% endif %}>Noise</option>
+        </select>
     </div>
 
     <div class="controls">
@@ -150,6 +155,7 @@
             const infoStepRate = document.getElementById('infoStepRate');
             const infoNote = document.getElementById('infoNote');
             const likedOnlyToggle = document.getElementById('likedOnlyToggle');
+            const orderSelect = document.getElementById('orderSelect');
             let selectedIds = [];
             let lastRendering = null;
 
@@ -217,6 +223,12 @@
             if (likedOnlyToggle) {
                 likedOnlyToggle.addEventListener('change', () => {
                     updateFilters({ liked: likedOnlyToggle.checked ? '1' : null });
+                });
+            }
+
+            if (orderSelect) {
+                orderSelect.addEventListener('change', () => {
+                    updateFilters({ order: orderSelect.value || null });
                 });
             }
 


### PR DESCRIPTION
## Summary
- Track a `noise_score` for generated images and store it in the database
- Allow fetching and ordering images by noise level
- Add gallery controls to sort images by noise

## Testing
- `python -m py_compile stylegan_manager/db.py stylegan_manager/utils/__init__.py stylegan_manager/utils/noise.py stylegan_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb0caee44083259db17ca98400764e